### PR TITLE
additional formats in latest rfcs

### DIFF
--- a/ietfdata/rfcindex.py
+++ b/ietfdata/rfcindex.py
@@ -283,7 +283,7 @@ class RfcEntry:
     def content_url(self, required_format: str) -> Optional[str]:
         for fmt in self.formats:
             if fmt == required_format:
-                if required_format == "ASCII":
+                if required_format in [ "ASCII", "TEXT"] :
                     return "https://www.rfc-editor.org/rfc/" + self.doc_id.lower() + ".txt"
                 elif required_format == "PS":
                     return "https://www.rfc-editor.org/rfc/" + self.doc_id.lower() + ".ps"
@@ -291,6 +291,8 @@ class RfcEntry:
                     return "https://www.rfc-editor.org/rfc/" + self.doc_id.lower() + ".pdf"
                 elif required_format == "HTML":
                     return "https://www.rfc-editor.org/rfc/" + self.doc_id.lower() + ".html"
+                elif required_format == "XML":
+                    return "https://www.rfc-editor.org/rfc/" + self.doc_id.lower() + ".xml"
                 else:
                     return None
         return None


### PR DESCRIPTION
Later RFCs have changed the format type from "ASCII"   to "TEXT" for .txt files. 
Later RFCs also have XML formats. 