### PR TITLE
Fix unnecessary metadata regeneration

### DIFF
--- a/ietfdata/mailarchive.py
+++ b/ietfdata/mailarchive.py
@@ -166,13 +166,12 @@ class MailingList:
                     metadata : Dict[str, Any] = {}
                     message_text = None
                     for helper in self._helpers:
+                        metadata = {**metadata, **(helper.deserialise(serialised_metadata[msg_id_str]))}
                         if not all(metadata_field in metadata for metadata_field in helper.metadata_fields):
                             if message_text is None:
                                 message_text = self.raw_message(msg_id)
                                 self.log.info(F"{type(helper).__name__}: scan message {self._list_name}/{msg_id:06} for metadata")
                                 metadata = {**metadata, **(helper.scan_message(message_text))}
-                        else:
-                            metadata = {**metadata, **(helper.deserialise(serialised_metadata[msg_id_str]))}
                     self._msg_metadata[msg_id] = metadata
         else:
             self.log.info(F"no metadata cache for mailing list {self._list_name}")

--- a/ietfdata/mailhelper_headerdata.py
+++ b/ietfdata/mailhelper_headerdata.py
@@ -74,4 +74,4 @@ class HeaderDataMailHelper(MailArchiveHelper):
 
 
     def deserialise(self, metadata: Dict[str, str]) -> Dict[str, Any]:
-        return {"from_name": metadata["from_name"], "from_addr": metadata["from_addr"], "timestamp": datetime.fromisoformat(metadata["timestamp"])}
+        return {"from_name": metadata["from_name"], "from_addr": metadata["from_addr"], "timestamp": datetime.fromisoformat(metadata["timestamp"]) if metadata["timestamp"] is not None else None}

--- a/ietfdata/mailhelper_headerdata.py
+++ b/ietfdata/mailhelper_headerdata.py
@@ -73,5 +73,5 @@ class HeaderDataMailHelper(MailArchiveHelper):
                 "timestamp" : metadata["timestamp"].isoformat() if metadata["timestamp"] is not None else None}
 
 
-    def deserialise(self, metadata: Dict[str, str]) -> Dict[str, Any]:
+    def deserialise(self, metadata: Dict[str, Any]) -> Dict[str, Any]:
         return {"from_name": metadata["from_name"], "from_addr": metadata["from_addr"], "timestamp": datetime.fromisoformat(metadata["timestamp"]) if metadata["timestamp"] is not None else None}


### PR DESCRIPTION
Fixes a bug where metadata was _always_ regenerated when a ```MailingList``` was instantiated, and only scans messages where a ```MailHelper``` provides fields that are not in the cache.