### PR TITLE
Add metadata namespaces and versioning

### DIFF
--- a/ietfdata/mailarchive.py
+++ b/ietfdata/mailarchive.py
@@ -152,7 +152,7 @@ class MailingList:
     _archive_urls      : Dict[str, int]
     _helpers           : List[MailArchiveHelper]
     _msg_metadata      : Dict[int, Dict[str, Any]]
-    _cached_metadata   : Dict[str, Dict[str, str]]
+    _cached_metadata   : Dict[str, Dict[str, Any]]
 
     def __init__(self, cache_dir: Path, list_name: str, helpers: List[MailArchiveHelper] = []):
         logging.basicConfig(level=os.environ.get("IETFDATA_LOGLEVEL", "INFO"))
@@ -173,7 +173,7 @@ class MailingList:
         if metadata_cache.exists():
             with open(metadata_cache, "r") as metadata_file:
                 self._cached_metadata = json.load(metadata_file)
-                message_metadata = self._cached_metadata["message_metadata"]
+                message_metadata = self._cached_metadata["message_metadata"] # type: Dict[str, Dict[str, Dict[str, str]]]
                 for msg_id_str in message_metadata:
                     msg_id = int(msg_id_str)
                     if not Path(self._cache_folder, F"{msg_id:06d}.msg").exists():
@@ -184,7 +184,7 @@ class MailingList:
                     for helper in self._helpers:
                         if helper.name in self._cached_metadata["helpers"] and helper.version != self._cached_metadata["helpers"][helper.name]:
                             self.log.info(F"{helper.name}: version changed, discarding cached metadata")
-                            message_metadata[msg_id_str].pop(helper.name)
+                            (message_metadata[msg_id_str]).pop(helper.name)
                         if helper.name not in message_metadata[msg_id_str] or not all(metadata_field in message_metadata[msg_id_str][helper.name] for metadata_field in helper.provided_fields):
                             if message_text is None:
                                 message_text = self.raw_message(msg_id)

--- a/ietfdata/mailarchive.py
+++ b/ietfdata/mailarchive.py
@@ -180,6 +180,9 @@ class MailingList:
                     metadata : Dict[str, Dict[str, Any]] = {}
                     message_text = None
                     for helper in self._helpers:
+                        if helper.version != serialised_metadata["helpers"][helper.name]:
+                            self.log.info(F"{helper.name}: version changed, discarding cached metadata")
+                            message_metadata[msg_id_str].pop(helper.name)
                         if helper.name not in message_metadata[msg_id_str] or not all(metadata_field in message_metadata[msg_id_str][helper.name] for metadata_field in helper.provided_fields):
                             if message_text is None:
                                 message_text = self.raw_message(msg_id)
@@ -277,7 +280,7 @@ class MailingList:
         for msg_id in self.message_indices():
             include_msg = True
             for helper in self._helpers:
-                if not helper.filter(self._msg_metadata[msg_id], **kwargs):
+                if not helper.filter(self._msg_metadata[msg_id][helper.name], **kwargs):
                     include_msg = False
                     break
             if include_msg:

--- a/ietfdata/mailarchive.py
+++ b/ietfdata/mailarchive.py
@@ -247,7 +247,7 @@ class MailingList:
             serialised_metadata["helpers"] = {**serialised_metadata["helpers"], **self._cached_metadata.get("helpers", {})}
             for msg_id in self._msg_metadata:
                 serialised_metadata["message_metadata"][msg_id] = self.serialise_message(msg_id)
-                serialised_metadata["message_metadata"][msg_id] = {**serialised_metadata["message_metadata"][msg_id], **(self._cached_metadata["message_metadata"].get(str(msg_id), {}))}
+                serialised_metadata["message_metadata"][msg_id] = {**serialised_metadata["message_metadata"][msg_id], **(self._cached_metadata.get("message_metadata", {}).get(str(msg_id), {}))}
             json.dump(serialised_metadata, metadata_file, indent=4)
         metadata_cache_tmp.rename(metadata_cache)
 

--- a/ietfdata/mailarchive.py
+++ b/ietfdata/mailarchive.py
@@ -151,7 +151,7 @@ class MailingList:
     _num_messages : int
     _archive_urls : Dict[str, int]
     _helpers      : List[MailArchiveHelper]
-    _msg_metadata : Dict[int, Dict[str, str]]
+    _msg_metadata : Dict[int, Dict[str, Any]] = {}
 
     def __init__(self, cache_dir: Path, list_name: str, helpers: List[MailArchiveHelper] = []):
         logging.basicConfig(level=os.environ.get("IETFDATA_LOGLEVEL", "INFO"))
@@ -238,7 +238,7 @@ class MailingList:
         metadata_cache = Path(self._cache_folder, "metadata.json")
         metadata_cache_tmp = Path(self._cache_folder, "metadata.json.tmp")
         with open(metadata_cache_tmp, "w") as metadata_file:
-            serialised_metadata = {"helpers": {}, "message_metadata": {}}
+            serialised_metadata = {"helpers": {}, "message_metadata": {}} # type: Dict[str, Dict[Any, Any]]
             serialised_metadata["helpers"] = {}
             for helper in self._helpers:
                 serialised_metadata["helpers"][helper.name] = helper.version
@@ -248,7 +248,7 @@ class MailingList:
         metadata_cache_tmp.rename(metadata_cache)
 
 
-    def serialise_message(self, msg_id: int) -> Dict[str, str]:
+    def serialise_message(self, msg_id: int) -> Dict[str, Dict[str, str]]:
         metadata : Dict[str, Dict[str, str]] = {}
         for helper in self._helpers:
             metadata[helper.name] = helper.serialise(self._msg_metadata[msg_id][helper.name])
@@ -349,7 +349,7 @@ class MailingList:
                     self._msg_metadata[msg_id] = {}
                     for helper in self._helpers:
                         self.log.info(F"{helper.name}: scan message {self._list_name}/{msg_id:06} for metadata")
-                        self._msg_metadata[msg_id] = {**(helper.scan_message(e)), **(self._msg_metadata[msg_id])}
+                        self._msg_metadata[msg_id][helper.name] = helper.scan_message(e)
 
             with open(aa_cache_tmp, "w") as aa_cache_file:
                 json.dump(self._archive_urls, aa_cache_file)

--- a/ietfdata/mailarchive.py
+++ b/ietfdata/mailarchive.py
@@ -106,7 +106,9 @@ class MailingListMessage:
 
     def __init__(self, message: Message, metadata: Dict[str, Any]):
         self.message = message
-        self._metadata = metadata
+        self._metadata = {}
+        for helper_name in metadata:
+            self._metadata = {**self._metadata, **metadata[helper_name]}
 
 
     def has_metadata(self, name: str) -> bool:

--- a/ietfdata/mailhelper_datatracker.py
+++ b/ietfdata/mailhelper_datatracker.py
@@ -29,13 +29,15 @@ import ietfdata.datatracker as dt
 from ietfdata.mailarchive import *
 
 class DatatrackerMailHelper(MailArchiveHelper):
-    metadata_fields = ["from_person", "related_docs"]
+    name    = "Datatracker"
+    version = "r1"
+    provided_fields = ["from_person", "related_docs"]
 
     def __init__(self, datatracker: dt.DataTracker):
         logging.basicConfig(level=os.environ.get("IETFDATA_LOGLEVEL", "INFO"))
         self.log = logging.getLogger("ietfdata")
         self.dt = datatracker
-        
+
 
     def scan_message(self, msg: Message) -> Dict[str, Any]:
         from_name, from_addr = email.utils.parseaddr(str(msg["From"]).replace("\uFFFD", "?"))

--- a/ietfdata/mailhelper_headerdata.py
+++ b/ietfdata/mailhelper_headerdata.py
@@ -31,7 +31,9 @@ import logging
 from ietfdata.mailarchive        import *
 
 class HeaderDataMailHelper(MailArchiveHelper):
-    metadata_fields = ["from_name", "from_addr", "timestamp"]
+    name    = "HeaderData"
+    version = "r1"
+    provided_fields = ["from_name", "from_addr", "timestamp"]
 
     def __init__(self):
         logging.basicConfig(level=os.environ.get("IETFDATA_LOGLEVEL", "INFO"))


### PR DESCRIPTION
This restructures metadata cache files, to add support for namespaces and versioning. Any metadata.json files generated with previous versions will be incompatible, and should be deleted before running with this version.

The new format allows:

- MailArchiveHelpers to provide a name, version, and a list of provided fields;
- Metadata to be regenerated if a MailArchiveHelper's version is changed, or a new field is provided;
- Metadata fields to be removed from the cache when they are no longer provided by an attached MailArchiveHelper;
- Metadata to remain in the cache if the MailArchiveHelper that generated it is not attached.

In summary, the metadata cache can be better maintained, with fields cached, regenerated, and deleted more appropriately.
