### PR TITLE
Changes for the Example notebook

### DIFF
--- a/ietfdata/mailarchive.py
+++ b/ietfdata/mailarchive.py
@@ -37,6 +37,7 @@ from datetime      import datetime, timedelta
 from typing        import List, Optional, Tuple, Dict, Iterator, Type, TypeVar, Any
 from pathlib       import Path
 from email.message import Message
+from email         import policy
 from imapclient    import IMAPClient
 
 # =================================================================================================
@@ -272,7 +273,7 @@ class MailingList:
     def raw_message(self, msg_id: int) -> Message:
         cache_file = Path(self._cache_folder, "{:06d}.msg".format(msg_id))
         with open(cache_file, "rb") as inf:
-            message = email.message_from_binary_file(inf)
+            message = email.message_from_binary_file(inf, policy=policy.default)
         return message
 
 
@@ -353,7 +354,7 @@ class MailingList:
                         outf.write(msg[b"RFC822"])
                     fetch_file.rename(cache_file)
 
-                    e = email.message_from_bytes(msg[b"RFC822"])
+                    e = email.message_from_bytes(msg[b"RFC822"], policy=policy.default)
                     if e["Archived-At"] is not None:
                         list_name, msg_hash = _parse_archive_url(e["Archived-At"])
                         self._archive_urls[msg_hash] = msg_id

--- a/ietfdata/mailarchive.py
+++ b/ietfdata/mailarchive.py
@@ -443,11 +443,18 @@ class MailArchive:
 
         imap = IMAPClient(host='imap.ietf.org', ssl=False, use_uid=True)
         imap.login("anonymous", "anonymous")
+        success , fail = 0, 0
         for index, ml_name in enumerate(ml_names):
-            print(F"Updating list {index+1:4d}/{num_list:4d}: {ml_name} ", end="", flush=True)
-            ml = self.mailing_list(ml_name, _reuse_imap=imap)
-            nm = ml.update(_reuse_imap=imap)
-            print(F"({ml.num_messages()} messages; {len(nm)} new)")
+            try:
+                print(F"Updating list {index+1:4d}/{num_list:4d}: {ml_name} ", end="", flush=True)
+                ml = self.mailing_list(ml_name, _reuse_imap=imap)
+                nm = ml.update(_reuse_imap=imap)
+                print(F"({ml.num_messages()} messages; {len(nm)} new)")
+                success += 1
+            except Exception as e:
+                self.log.warn("Exception during download of list %s --> %s"  % (ml_name, str(e)))
+                fail +=1
+        print("Updated without errors: %d / %d" % (success, success + fail))
         imap.logout()
 
 

--- a/ietfdata/mailarchive.py
+++ b/ietfdata/mailarchive.py
@@ -346,7 +346,15 @@ class MailingList:
             aa_cache_tmp = Path(self._cache_folder, "aa-cache.json.tmp")
             aa_cache.unlink()
 
+            last_keepalive = datetime.now()
             for msg_id, msg in imap.fetch(msg_fetch, "RFC822").items():
+                curr_keepalive = datetime.now()
+                if (curr_keepalive - last_keepalive) > timedelta(seconds=10):
+                    if _reuse_imap is not None:
+                        self.log.info("imap keepalive")
+                        _reuse_imap.noop()
+                        last_keepalive = curr_keepalive
+ 
                 cache_file = Path(self._cache_folder, F"{msg_id:06d}.msg")
                 fetch_file = Path(self._cache_folder, F"{msg_id:06d}.msg.download")
                 if not cache_file.exists():

--- a/ietfdata/mailhelper_headerdata.py
+++ b/ietfdata/mailhelper_headerdata.py
@@ -52,7 +52,8 @@ class HeaderDataMailHelper(MailArchiveHelper):
             if msg_date is not None:
                 timestamp = datetime.fromtimestamp(time.mktime(msg_date))
         except Exception as e:
-            self.log.error(f"HeaderDataMailHelper: could not parse message `Date` header - {msg['Date']}")
+            #self.log.error(f"HeaderDataMailHelper: could not parse message `Date` header - {msg['Date']}") # this seems to be giving me errors
+            self.log.error(f"HeaderDataMailHelper: could not parse message `Date` header.") # this seems to be giving me errors
             pass
         return {"from_name"   : from_name,
                 "from_addr"   : from_addr,


### PR DESCRIPTION
These are changes that are needed in the "ietfdata" code to make the analysis notebook work as intended. They mainly consist of minor additions/changes to error handling of the borderline cases and introducing some imap keepalives during download (also I changed policy to be policy.default in message_from_bytes and message_from_binary file).