### PR TITLE
Submission `document_date` field can be null

### DIFF
--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -310,7 +310,7 @@ class Submission(Resource):
     auth_key        : str
     authors         : str   # See the parse_authors() method
     checks          : List[SubmissionCheckURI]
-    document_date   : datetime
+    document_date   : Optional[datetime]
     draft           : DocumentURI
     file_size       : Optional[int]
     file_types      : str   # e.g., ".txt,.xml"
@@ -2020,7 +2020,7 @@ class DataTracker:
 
         meta = self._cache_load_metadata(obj_type_uri)
 
-        # URIs under /api/v1/name/ are internal names used by the datatracker. 
+        # URIs under /api/v1/name/ are internal names used by the datatracker.
         # Delete and recreate these caches if the datatracker version changed.
         if self._hints[obj_type_uri.uri].update_strategy == "V" and dt_version_changed:
             self.log.info(f"_cache_update: drop {obj_type_uri} due to datatracker version change")

--- a/ietfdata/datatracker_ext.py
+++ b/ietfdata/datatracker_ext.py
@@ -144,7 +144,7 @@ class DataTrackerExt(DataTracker):
                     found = True
                     break
             if not found:
-                drafts.append(DraftHistory(draft, submission.rev, submission.document_date, submission))
+                drafts.append(DraftHistory(draft, submission.rev, submission.submission_date, submission))
 
         # Step 3: Use related_documents() to find additional drafts this replaces:
         for related in self.related_documents(source=draft, relationship_type=self.relationship_type_from_slug("replaces")):

--- a/tests/test_datatracker.py
+++ b/tests/test_datatracker.py
@@ -1660,7 +1660,7 @@ class TestDatatracker(unittest.TestCase):
 
     def test_group_role_histories_email(self) -> None:
         group_role_histories = list(self.dt.group_role_histories(email="csp@csperkins.org"))
-        self.assertEqual(len(group_role_histories), 42)
+        self.assertEqual(len(group_role_histories), 44)
 
 
     def test_group_role_histories_group(self) -> None:
@@ -1679,7 +1679,7 @@ class TestDatatracker(unittest.TestCase):
 
     def test_group_role_histories_person(self) -> None:
         group_role_histories = list(self.dt.group_role_histories(person=self.dt.person(PersonURI("/api/v1/person/person/20209/"))))
-        self.assertEqual(len(group_role_histories), 42)
+        self.assertEqual(len(group_role_histories), 44)
 
 
     def test_group_state_change_event(self) -> None:


### PR DESCRIPTION
The `document_date` field for Submission objects can be null (e.g., https://datatracker.ietf.org/api/v1/submit/submission/40696/)