### PR TITLE
Prevent infinite recursion where draft history contains loops

### DIFF
--- a/ietfdata/datatracker_ext.py
+++ b/ietfdata/datatracker_ext.py
@@ -167,7 +167,7 @@ class DataTrackerExt(DataTracker):
 
         # Step 4: Process the drafts this replaces, to find earlier versions:
         for r in replaces:
-            if r.name != draft.name and draft not in drafts:
+            if r.name != draft.name:
                 drafts.extend(self.draft_history(r, drafts_seen=drafts_seen))
 
         return list(reversed(sorted(drafts, key=lambda d: d.date)))

--- a/ietfdata/datatracker_ext.py
+++ b/ietfdata/datatracker_ext.py
@@ -101,13 +101,18 @@ class DataTrackerExt(DataTracker):
 
 
 
-    def draft_history(self, draft: Document) -> List[DraftHistory]:
+    def draft_history(self, draft: Document, drafts_seen: List[Document] = []) -> List[DraftHistory]:
         """
         Find the previous versions of an Internet-Draft
         """
         assert draft.type == DocumentTypeURI("/api/v1/name/doctypename/draft/")
 
         drafts : List[DraftHistory] = []
+
+        if draft in drafts_seen:
+            return []
+        else:
+            drafts_seen.append(draft)
 
         # Step 1: Use document_events() to find previous versions of the draft.
         for event in self.document_events(doc=draft, event_type="new_revision"):
@@ -162,8 +167,8 @@ class DataTrackerExt(DataTracker):
 
         # Step 4: Process the drafts this replaces, to find earlier versions:
         for r in replaces:
-            if r.name != draft.name:
-                drafts.extend(self.draft_history(r))
+            if r.name != draft.name and draft not in drafts:
+                drafts.extend(self.draft_history(r, drafts_seen=drafts_seen))
 
         return list(reversed(sorted(drafts, key=lambda d: d.date)))
 


### PR DESCRIPTION
Some draft histories (e.g., for RFC7982) contain loops, which can cause infinite recursion 