### PR TITLE
Allow empty event type when fetching document events

### DIFF
--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -2808,7 +2808,7 @@ class DataTracker:
         if by is not None:
             url.params["by"]   = by.id
         if event_type is not None:
-            url.params["type"]     = event_type
+            url.params["type"] = event_type
         return self._retrieve_multi(url, DocumentEvent)
 
 

--- a/ietfdata/datatracker.py
+++ b/ietfdata/datatracker.py
@@ -2807,7 +2807,8 @@ class DataTracker:
             url.params["doc"]  = doc.id
         if by is not None:
             url.params["by"]   = by.id
-        url.params["type"]     = event_type
+        if event_type is not None:
+            url.params["type"]     = event_type
         return self._retrieve_multi(url, DocumentEvent)
 
 

--- a/tests/test_datatracker.py
+++ b/tests/test_datatracker.py
@@ -1039,6 +1039,12 @@ class TestDatatracker(unittest.TestCase):
         self.assertEqual(de[18].id, 478637)
 
 
+    def test_document_events_without_type(self) -> None:
+        p  = self.dt.person_from_email("csp@csperkins.org")
+        d  = self.dt.document_from_draft("draft-ietf-avtcore-rtp-circuit-breakers")
+        de = list(self.dt.document_events(doc=d, by=p))
+        self.assertEqual(len(de), 22)
+
 
     def test_ballot_position_name(self) -> None:
         bp = self.dt.ballot_position_name(BallotPositionNameURI("/api/v1/name/ballotpositionname/moretime/"))


### PR DESCRIPTION
Hello! While using the library, I encountered an error when trying to retrieve all document events without specifying an event type. I assume this was not intended, as the parameter is specified as optional, however, when left as is, the assertion in `_retrieve_multi` when iterating over the parameters fails. I added a check similar to the other parameters, and a relevant test. Please let me know if there is anything I should change. Thank you!