### PR TITLE
Create index on `in-reply-to` header

### DIFF
--- a/ietfdata/mailarchive2.py
+++ b/ietfdata/mailarchive2.py
@@ -759,6 +759,8 @@ class MailArchive:
                                        ], unique=False)
         self._db.metadata.create_index([('message_id', ASCENDING)
                                        ], unique=False)
+        self._db.metadata.create_index([('in_reply_to', ASCENDING)
+                                       ], unique=False)
         self._fs = GridFS(self._db)
         # Create other state:
         self._mailing_lists = {}


### PR DESCRIPTION
Adds an index on the `in_reply_to` field to improve `replies()` performance