### PR TITLE
Fix missing index in mailarchive2.py

### DIFF
--- a/ietfdata/mailarchive2.py
+++ b/ietfdata/mailarchive2.py
@@ -760,7 +760,7 @@ class MailArchive:
                                        ], unique=False)
         self._db.metadata.create_index([('message_id', ASCENDING)
                                        ], unique=False)
-        self._db.metadata.create_index([('in_reply_to', ASCENDING)
+        self._db.messages.create_index([('in_reply_to', ASCENDING)
                                        ], unique=False)
         self._fs = GridFS(self._db)
         # Create other state:


### PR DESCRIPTION
Created index on "in_reply_to" on db.messages (it was on db.metadata by mistake). This significantly speeds up iterating over the message tree within a thread in the segmentation code.