### PR TITLE
fixing output() function to correctly call self.toJSON()

### DIFF
--- a/ietfdata/tools/participants_affiliations.py
+++ b/ietfdata/tools/participants_affiliations.py
@@ -359,7 +359,7 @@ class ParticipantsAffiliations:
     def output(self,path) -> None:
         with open(path,'w') as f:
             print(f"About to write output to:{path}")
-            f.write(participants_affiliations.toJSON())
+            f.write(self.toJSON())
     
     ## String output for debugging
     def __str__(self):


### PR DESCRIPTION
This addresses a typo in output() method. 
Instead of calling self.toJSON(), it called a variable `participants_affiliations` in `main()`.