### PR TITLE
Switching from if <variable> is None to assert <variable> is not None.

### DIFF
--- a/ietfdata/tools/organisations.py
+++ b/ietfdata/tools/organisations.py
@@ -318,7 +318,6 @@ class OrganisationMatcher:
 
 
     def add(self, organisation:str, email:str):
-        assert organisation is not None
         if organisation == "":
             warnings.warn("organisation is an empty string, ignored.")
             return

--- a/ietfdata/tools/organisations.py
+++ b/ietfdata/tools/organisations.py
@@ -318,9 +318,7 @@ class OrganisationMatcher:
 
 
     def add(self, organisation:str, email:str):
-        if organisation is None:
-            warnings.warn("organisation is None, ignored.")
-            return 
+        assert organisation is not None
         if organisation == "":
             warnings.warn("organisation is an empty string, ignored.")
             return


### PR DESCRIPTION
mypy flagged that `organisation` in `add()` function will never be None so the following if-statement will never be `True`. https://github.com/glasgow-ipl/ietfdata/blob/ad942afe4c5a3ded29d6984463401583d1fec857/ietfdata/tools/organisations.py#L321

This was added initially to gently warn the user of this Class and this Method `add()` but this probably should just be an `assert` instead and kill the program. 

Fixes #162 